### PR TITLE
eliminate path deprecation warnings by replacing .path. with .IO.

### DIFF
--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -181,8 +181,8 @@ class Template::Mustache {
 
         sub get-template($template, :$silent) {
             sub read-template-file($dir is copy) {
-                $dir = $*SPEC.catdir: $*PROGRAM_NAME.path.dirname, $dir
-                    if $dir.path.is-relative;
+                $dir = $*SPEC.catdir: $*PROGRAM_NAME.IO.dirname, $dir
+                    if $dir.IO.is-relative;
                 for @$extension -> $ext {
                     my $file = $*SPEC.catfile($dir, $template ~ $ext).IO;
                     return $file.slurp;

--- a/t/91-specs.t
+++ b/t/91-specs.t
@@ -46,7 +46,7 @@ sub load-specs (Str $specs-dir) {
     }
 
     plan @specs + 1;
-    todo "You must clone github.com/mustache/spec into '{$specs-dir.path.dirname}'"
+    todo "You must clone github.com/mustache/spec into '{$specs-dir.IO.dirname}'"
         if @specs == 0;
 
     ok @specs > 0 && @specs[0]<template>, "Specs files located";

--- a/t/92-specs-file.t
+++ b/t/92-specs-file.t
@@ -12,7 +12,7 @@ sub cleanup(:$rmdir = False) {
 END { cleanup(:rmdir); }
 
 mkdir $views;
-my $m = Template::Mustache.new: :from($views.path.basename);
+my $m = Template::Mustache.new: :from($views.IO.basename);
 for load-specs '../mustache-spec/specs' {
     cleanup;
     ("$views/specs-file-main" ~ $m.extension).IO.spurt: $_<template>;
@@ -62,7 +62,7 @@ sub load-specs (Str $specs-dir) {
     }
 
     plan @specs + 1;
-    todo "You must clone github.com/mustache/spec into '{$specs-dir.path.dirname}'"
+    todo "You must clone github.com/mustache/spec into '{$specs-dir.IO.dirname}'"
         if @specs == 0;
 
     ok @specs > 0 && @specs[0]<template>, "Specs files located";


### PR DESCRIPTION
Similar to but more complete than tony-o's path deprecation fix, but with no extra changes anywhere. This is purely about `s/.path./.IO./`