### PR TITLE
Small change to allow object stringification to work

### DIFF
--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -305,7 +305,7 @@ class Template::Mustache {
             #note "** \{ %val<type>: %val<val>";
             given %val<type> {
                 when 'comment' { '' }
-                when 'var' { encode-entities(get(@data, %val<val>)) }
+                when 'var' { encode-entities(~get(@data, %val<val>)) }
                 when 'qvar' { get(@data, %val<val>) }
                 when 'mmmvar' { get(@data, %val<val>) }
                 when 'delim' { '' }

--- a/t/10-objects.t
+++ b/t/10-objects.t
@@ -1,0 +1,14 @@
+v6;
+use Test;
+use Template::Mustache;
+
+class TestObj {
+    method Str() { "I am your father!" }
+}
+
+my $tm = Template::Mustache.new;
+is $tm.render('{{object}}', { object => TestObj.new }),
+    'I am your father!',
+    'Object stringifies';
+
+done;


### PR DESCRIPTION
Makes sure that whatever is passed is stringified before get-entities is called, to prevent ugly, avoidable errors.