### PR TITLE
Remove comments from META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -5,7 +5,7 @@
     "author": "Tim Smith",
     "description": "A logic-free, cross-language templating format",
     "depends": [
-        "JSON::Tiny",  # For Mustache tests
+        "JSON::Tiny",
     ],
     "license" : "https://www.gnu.org/licenses/lgpl.html",
     "production": 1,


### PR DESCRIPTION
They make JSON invalid and cause Template::Mustache to disappear from the ecosystem