### PR TITLE
make META.info spec compliant

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,9 +1,9 @@
 {
-    "perl": "v6",
+    "perl": "6",
     "name": "Template::Mustache",
     "version": "*",
     "auth": "github:softmoth",
-    "author": "Tim Smith",
+    "authors": ["Tim Smith"],
     "description": "A logic-free, cross-language templating format",
     "depends": [
     ],


### PR DESCRIPTION
the leading v in the perl version has been deprecated

this is a build message: "Please remove leading 'v' from perl version in Template::Mustache's meta info."

and there's no author attribute in the spec right now, it's just authors