### PR TITLE
Fix test to find its template file

### DIFF
--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -183,16 +183,14 @@ class Template::Mustache {
             sub read-template-file($dir is copy) {
                 $dir = $*SPEC.catdir: $*PROGRAM-NAME.IO.dirname, $dir
                     if $dir.IO.is-relative;
-                for @$extension -> $ext {
-                    my $file = $*SPEC.catfile($dir, $template ~ $ext).IO;
-                    return $file.slurp;
-                    CATCH {
-                        # RAKUDO: slurp throws X::Adhoc exception
-                        default {
-                            # Ignore it
-                        }
-                    }
-                }
+	        my $file = $extension.map({ $*SPEC.catfile($dir, $template ~ $ext).IO }).first(*.e);
+	        return $file.slurp if $file;
+	        CATCH {
+		    # RAKUDO: slurp throws X::Adhoc exception
+		    default {
+		        # Ignore it
+		    }
+	        }
                 #log_warn "Unable to find file for template '$template'" unless $silent;
                 return Nil;
             }

--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -183,7 +183,7 @@ class Template::Mustache {
             sub read-template-file($dir is copy) {
                 $dir = $*SPEC.catdir: $*PROGRAM-NAME.IO.dirname, $dir
                     if $dir.IO.is-relative;
-	        my $file = $extension.map({ $*SPEC.catfile($dir, $template ~ $ext).IO }).first(*.e);
+	        my $file = $extension.map({ $*SPEC.catfile($dir, $template ~ $_).IO }).first(*.e);
 	        return $file.slurp if $file;
 	        CATCH {
 		    # RAKUDO: slurp throws X::Adhoc exception


### PR DESCRIPTION
This was trying to slurp a non-existent file `hello.ms` instead of attempting the second extension to slurp the existing `hello.mustache`

Resolves #16