### PR TITLE
Optionally warn if template requires field missing from context

### DIFF
--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -4,6 +4,12 @@ my class X::Template::Mustache::CannotParse is Exception {
     method message() { "$!err ❮{$!str}❯" }
 }
 
+my class X::Template::Mustache::FieldNotFound is Exception {
+    has $.err = 'Field not found';
+    has $.str;
+    method message() { "$!err ❮{$!str}❯" }
+}
+
 class Template::Mustache {
     has $.extension = '.mustache';
     has $.from;
@@ -137,7 +143,7 @@ class Template::Mustache {
         }
     }
 
-    method render($template, %context, Bool :$literal, :$from, :$extension is copy) {
+    method render($template, %context, Bool :$literal, :$from, :$extension is copy, Bool :$warn = False) {
         if !$extension.defined {
             $extension = self ?? $!extension !! '.mustache';
         }
@@ -301,6 +307,9 @@ class Template::Mustache {
                     }
                 }
                 #note "get($field) is '$result.perl()'";
+                if !$result && $warn {
+                     warn X::Template::Mustache::FieldNotFound.new(:str($field));
+                }
                 return $section ?? ($result, $lambda) !! $result;
             }
 

--- a/t/06-warn.t
+++ b/t/06-warn.t
@@ -1,0 +1,19 @@
+use v6;
+use Test;
+use Template::Mustache;
+
+my $out;
+
+CONTROL {
+    default {
+        $out ~= "{.Str}\n";
+        .resume;
+    }
+}
+
+Template::Mustache.render('{{missing_field1}} {{missing_field2}} {{missing.field}}\n', {}, :warn);
+
+is elems($out ~~ m:g/'Field not found ❮missing_field' \d '❯'/), 2, 'Warn missing field(s)';
+like $out, /'Field not found ❮missing.field❯'/, 'Warn missing . field';
+
+done-testing;


### PR DESCRIPTION
This modification will allow for printing warning messages when a field referenced in a template is missing from context.

```
Template::Mustache.render(
    '{{missing_field1}} {{missing_field2}} {{missing.field}}\n',
{}, :warn);

# Field not found ❮missing_field1❯
# Field not found ❮missing_field2❯
# Field not found ❮missing.field❯
```

`render` will continue with the current behavior without the `:warn` flag.